### PR TITLE
Dev keep event end time

### DIFF
--- a/routes/admin/events.rb
+++ b/routes/admin/events.rb
@@ -284,7 +284,7 @@ get '/admin/events/:event_id/edit/?' do
 		:tools => tools,
 		:on_unl_events => on_unl_events,
 		:on_main_calendar => on_main_calendar,
-		:duration => 0
+		:duration => ((event.end_time - event.start_time)/60.0).round
 	}
 end
 


### PR DESCRIPTION
[Wiki page](https://github.com/cseseniordesign/reservations/wiki/Story-%2392-Keep-an-event's-end-time-when-editing-the-event)